### PR TITLE
docs/_config.yml: baseurl was missing to point to docs/

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,6 @@
 remote_theme: pmarsceill/just-the-docs
 #theme: just-the-docs
+baseurl: /main/docs
 color_scheme: dark
 heading_anchors: true
 aux_links:


### PR DESCRIPTION
Attempt to fix "edit this page on github" from lfashkeeper.org which otherwise points to eg https://github.com/linuxboot/flashkeeper/edit/main/index.md instead of https://github.com/linuxboot/flashkeeper/edit/main/docs/index.md