### PR TITLE
docs/_config.yml: modify gh_edit_path to point to '/docs/' not 'docs/' 

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -17,5 +17,5 @@ gh_edit_link: true
 gh_edit_link_text: "Edit this page on GitHub."
 gh_edit_repository: "https://github.com/linuxboot/flashkeeper"
 gh_edit_branch: "main"
-gh_edit_path: "docs/"
+gh_edit_path: "/docs/"
 gh_edit_view_mode: "edit"


### PR DESCRIPTION
beginning to be out of ideas. If this doesn't work, opening issue to track and fix out of trial and errors