### PR TITLE
Fix "Edit on Github" links, improve local Jekyll testing guide and refer to flashkeeper.org in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Flashkeeper
 ===
 
+[Visit Flashkeeper Documentation](https://flashkeeper.org)
+
 This project is developing Flashkeeper, a device that can be permanently installed on a common SOIC-8/WSON-8 flash chip. It attaches to the chip with a peel-and-stick layer and spring-loaded contacts or low-profile solder-down flex cable, interfacing with the SPI flash pins for easy write protection and external reprogramming (unbricking). For users concerned with physical attacks on their systems, for whom easy access to SPI flash pins may be seen as a risk, a variant including a microcontroller (MCU) is also being developed, allowing authenticated external reprogramming and WP control, and independently verifying the SPI flash image against a user-controlled signature each boot.
 
 [Flashkeeper: An NLnet NGI Zero Core funded project](https://nlnet.nl/project/Flashkeeper/)

--- a/docs/Development/Contributing-to-Flashkeeper-Wiki.md
+++ b/docs/Development/Contributing-to-Flashkeeper-Wiki.md
@@ -70,24 +70,15 @@ After installing Jekyll and the Just the Docs theme you may run the wiki on your
 * log in to GitHub and fork
 [linuxboot/flashkeeper](https://github.com/linuxboot/flashkeeper).  Then clone
 your fork locally.
-* Navigate to the base of the locally cloned repo and alter `_config.yml` to use
- the local theme.  The simplest way is to comment out the line that beings
- `remote_theme` and add a line `theme: "just-the-docs"`
-
- ```yaml
- # remote_theme: pmarsceill/just-the-docs
- theme: "just-the-docs"
- ```
+* Navigate to the base of the locally cloned repo 
 * Now start Jekyll with:
 ```bash
-$> jekyll serve
+$> jekyll serve --config docs/_config-local.yml
 ```
 This will start the Jekyll development web server and should be viewable in a
 web browser at `http://localhost:4000/`
 
 * create a branch in git for your changes
-* Make the desired changes, commit them.  **BE SURE NOT TO ADD `_config.yml`**
-to your changes.
 * Push the changes to your forked repo on github
 
 ### Testing Changes on Github

--- a/docs/_config-local.yml
+++ b/docs/_config-local.yml
@@ -1,6 +1,6 @@
-# This config is solely used by Github Pages
-# To test locally, refer to _config-local.yml
-remote_theme: pmarsceill/just-the-docs
+# This config is to run with jekyll locally:
+#  to preview your changes, do 'jekyll serve --config docs/_config-local.yml'
+theme: "just-the-docs"
 color_scheme: dark
 heading_anchors: true
 aux_links:
@@ -10,8 +10,8 @@ aux_links_new_tab: true
 
 title: Flashkeeper - Wiki
 
-last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter
-last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https://ruby-doc.org/stdlib-2.7.0/libdoc/time/rdoc/Time.html
+last_edit_timestamp: true
+last_edit_time_format: "%b %e %Y at %I:%M %p"
 
 # Footer "Edit this page on GitHub" link text
 gh_edit_link: true
@@ -21,7 +21,8 @@ gh_edit_branch: "main"
 gh_edit_source: docs
 gh_edit_view_mode: "edit"
 
-# baseurl: ""  # Uncomment if you need a baseurl for any reason
+# For local development, use an empty baseurl
+baseurl: ""  # This ensures paths resolve correctly during local testing
 
 # Include files and directories
 include:

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,22 +18,19 @@ nav_order: 1
 </details>
 <!-- markdownlint-enable MD033 -->
 
+# Overview
 
-Overview
-===
 Flashkeeper is a device designed for installation inside a computer, connecting to the SPI flash chip where firmware is stored and making write protection control and reprogramming easy and secure.
 
 ![design]({{ site.baseurl }}/images/chip.png)
 Solderless model of one option for spring-loaded contacts (pogo pins) interfacing with a SOIC-8 flash chip from above (FreeCAD)
 
-Further reading
----
+## Further reading
+
 * [Flashkeeper - Original project scope - Presentation at QubesOS mini-summit 2024](https://cfp.3mdeb.com/qubes-os-summit-2024/talk/FCENX9/)
 
-Learn more about Flashkeeper
----
+## Learn more about Flashkeeper
 
-* [Flashkeeper threat model]({{ site.baseurl }}/Flashkeeper-threat-model/) - goes into more
- detail about what classes of threats Flashkeeper attempts to counter.
+* [Flashkeeper threat model]({{ site.baseurl }}/Flashkeeper-threat-model/) - goes into more detail about what classes of threats Flashkeeper attempts to counter.
 * [Frequently Asked Questions]({{ site.baseurl }}/FAQ/)
 * [Prior Art/State of the Art prior of project start](https://cfp.3mdeb.com/qubes-os-summit-2024/talk/FCENX9/)


### PR DESCRIPTION
- Fixes 'Edit this page on github' footer: URLs were missing '/docs' in their paths.
- Adds a docs/_config-local.yml to be used for local iterations of documentation rendering prior of pushing future PR.
- Improves Contrib docs for "big changes", referring to Jekyl usage of _config-local.yml for local docs iteration prior of PR.
- Have README.md point to https://flashkeeper.org where /docs is rendered by github pages for each commit of this monorepo (so that docs can improve with code in single commit/PR).

We have a base!