### PR TITLE
docs/Community.md: add Matrix room address under Community page

### DIFF
--- a/docs/Community.md
+++ b/docs/Community.md
@@ -7,7 +7,7 @@ nav_order: 99
 
 Matrix channel
 ===
-TBD
+Official channel is at [#flashkeeper:matrix.org](https://matrix.to/#/#flashkeeper:matrix.org)
 
 Found a bug
 ===


### PR DESCRIPTION
Closes https://github.com/linuxboot/flashkeeper/issues/15

Up to being merged, changes visible at https://tlaurion.github.io/flashkeeper/community/